### PR TITLE
Add simple FastAPI poll app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# gpt-test
+# FastAPI Popularity Poll
+
+This project is a simple web application for voting in a popularity poll. It uses FastAPI for the backend and PostgreSQL for data storage.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configure PostgreSQL and update `DATABASE_URL` in `database.py` if needed.
+3. Initialize the database with some sample candidates:
+   ```bash
+   python init_db.py
+   ```
+4. Run the application:
+   ```bash
+   uvicorn main:app --reload
+   ```
+5. Open `http://localhost:8000` in your browser to vote and view results.

--- a/database.py
+++ b/database.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "postgresql://postgres:password@localhost/polls"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,16 @@
+import models
+from database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+def main():
+    db = SessionLocal()
+    if db.query(models.Candidate).count() == 0:
+        names = ["Alice", "Bob", "Charlie"]
+        for name in names:
+            db.add(models.Candidate(name=name))
+        db.commit()
+    db.close()
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,39 @@
+from typing import List
+from fastapi import FastAPI, Depends, Form, Request
+from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.orm import Session
+
+import models
+from database import SessionLocal, engine
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+templates = Jinja2Templates(directory="templates")
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.get("/")
+def read_root(request: Request, db: Session = Depends(get_db)):
+    candidates = db.query(models.Candidate).all()
+    return templates.TemplateResponse("index.html", {"request": request, "candidates": candidates})
+
+@app.post("/vote")
+def vote(candidate_ids: List[int] = Form(...), db: Session = Depends(get_db)):
+    for candidate_id in candidate_ids:
+        candidate = db.query(models.Candidate).filter(models.Candidate.id == candidate_id).first()
+        if candidate:
+            candidate.votes += 1
+    db.commit()
+    return RedirectResponse("/", status_code=303)
+
+@app.get("/results")
+def get_results(db: Session = Depends(get_db)):
+    candidates = db.query(models.Candidate).all()
+    return {c.name: c.votes for c in candidates}

--- a/models.py
+++ b/models.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from database import Base
+
+class Candidate(Base):
+    __tablename__ = "candidates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+    votes = Column(Integer, default=0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+sqlalchemy
+psycopg2-binary
+jinja2

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Popularity Poll</title>
+</head>
+<body>
+    <h1>Vote for your favorite candidate</h1>
+    <form action="/vote" method="post">
+        {% for candidate in candidates %}
+        <input type="checkbox" name="candidate_ids" value="{{ candidate.id }}" id="cand_{{ candidate.id }}">
+        <label for="cand_{{ candidate.id }}">{{ candidate.name }} ({{ candidate.votes }} votes)</label><br>
+        {% endfor %}
+        <button type="submit">Submit Vote</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create FastAPI app with PostgreSQL using SQLAlchemy
- provide template for voting and viewing totals
- include script to initialize database with sample data
- document setup and running instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eed386e5883278d2a1b8d2924d639